### PR TITLE
Update 2023-03-14 1005H | v0.7.0-main-merger-from-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ just joking, I am just playing around with containerizing my self-host setup (tr
 
 ### Supporting Architectures
 + maxwaldorf/guacamole    : AMD64 (x86_64), arm64v8
-+ pihole/pi-hole          : AMD64 (x86_64), armv7 and above, arm64v7 and above etc
++ pihole/pi-hole          : AMD64 (x86_64), armv7 and above, arm64v7 and above etc; Supporting armv6 as of 2023-03-14
 + hwdsl2/ipsec-vpn-server : AMD64 (x86_64), armv7 and above, arm64v7 and above etc.
 + codercom/code-server    : amd64, arm64, amd64
++ mvance/unbound          : AMD64 (x86_64) and above
++ mvance/unbound-rpi      : armv7 and above; for Raspberry Pi
 
 ### Notes
 - Do note that the following applications may have issues running on docker due to reasons such as incompatibility with the architecture (possible reasons will be specified below).
@@ -21,7 +23,7 @@ just joking, I am just playing around with containerizing my self-host setup (tr
         - codercom/code-server : Supports only amd64 and arm64 and x86_64/amd64 devices
             + For ARM 32-bit (i.e. armvhf) support : use 'linuxserver/code-server'
         + maxwaldorf/guacamole : works for x86_64 and arm64v8, no support for 32-bits (armvhf); Tested - Resulted in "does not have matching manifest list for arm/v7" error
-        + pi-hole : Incompatible with ARMv6 - container will keep stopping and running/restarting; only ARMv7 and above, AMD64, x86_64 etc.
+        + unbound(-rpi) : Incompatible with ARMv6 - container will keep stopping and running/restarting; only ARMv7 and above, AMD64, x86_64 etc.
         + hwdsl2  : Incompatible with ARMv6 - container will keep stopping and running/restarting; only ARMv7 and above, AMD64, x86_64 etc.
 
 ### Quickstart Guide

--- a/services/README.md
+++ b/services/README.md
@@ -27,5 +27,6 @@ The services found here are all generally useful tools and utilities used in a h
 - sqlite-browser : WebGUI Database Management System
     - author
         + linuxserver
+- unbound : DNS Resolver
 - uptime kuma : Monitoring utility
 - wireguard : VPN server

--- a/services/pi-hole/docker-compose.yaml
+++ b/services/pi-hole/docker-compose.yaml
@@ -15,14 +15,20 @@ services:
           - "80:80/tcp"
           - "443:443/tcp"
         environment:
-          TZ: 'Asia/Singapore' # This is the timezone
+          # TZ: 'Region/City' # This is the timezone
+          ### Timezone and locale
+          # TZ: 'Region/City'
+          ### WebUI Environment Variables
+          # WEBPASSWORD: "Password-here"
+          WEBPASSWORD_FILE: './pihole/secrets/WebPasswords' # WebUI Password File; Place your WEBPASSWORD secret here; Related to 'WEBPASSWORD'
+          ### FTL DNS
+          FTLCONF_LOCAL_IPV4: your-server-ipv4-address ### Set your server IP here
         volumes:
           - './pihole/etc-pihole/:/etc/pihole/'
           - './pihole/etc-dnsmasq.d/:/etc/dnsmasq.d/'
         dns:
-          - 127.0.0.1
-          - 1.1.1.1
-          - 192.168.1.123
+          - 8.8.8.8
+          - 8.8.4.4
         cap_add:
           - NET_ADMIN
         restart: always

--- a/services/pi-hole/pihole/secrets/WebPasswords
+++ b/services/pi-hole/pihole/secrets/WebPasswords
@@ -1,0 +1,1 @@
+# Please replace this with your WEBPASSWORD secret here (aka your pihole WebUI Admin Password)

--- a/services/unbound/README.md
+++ b/services/unbound/README.md
@@ -1,0 +1,17 @@
+# Unbound DNS resolver
+
+## Introduction
++ There are quite afew (albeit unofficial) Unbound docker-compose files out there
+- However, there are some authors that are widely used, namely
+    + [MatthewVance](https://github.com/MatthewVance)
+
+## System Design
++ This docker-compose snippet is created based on MatthewVance's Dockerfile image, however, you can just change the 'image' tag if you have created your own, as this docker-compose snippet is created to be universal/customizable
+
+## Architecture differences
++ Due to differences in support for different architectures, the Dockerfile maintainers may also have seperate repositories for different architectures
++ Hence, I will be seperating the snippets and files required based on Architecture (if available)
+
+## Repositories
++ [MatthewVance/unbound-docker (General)](https://github.com/MatthewVance/unbound-docker)
++ [MatthewVance/unbound-docker (Raspberry Pi/ARM)](https://github.com/MatthewVance/unbound-docker-rpi)

--- a/services/unbound/general/docker-compose.yaml
+++ b/services/unbound/general/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3.5"
+services:
+  unbound:
+    image: 'mvance/unbound:latest'
+    container_name: 'unbound'
+    ports:
+      - "5335:53/tcp"
+      - "5335:53/udp"
+    restart: unless-stopped
+    volumes:
+      - "./unbound.d/etc-unbound/unbound/:/etc/unbound/"

--- a/services/unbound/general/unbound.d/etc-unbound/unbound/unbound.conf
+++ b/services/unbound/general/unbound.d/etc-unbound/unbound/unbound.conf
@@ -1,0 +1,10 @@
+# Unbound configuration file for Debian.
+#
+# See the unbound.conf(5) man page.
+#
+# See /usr/share/doc/unbound/examples/unbound.conf for a commented
+# reference config file.
+#
+# The following line includes additional configuration files from the
+# /etc/unbound/unbound.conf.d directory.
+include-toplevel: "/etc/unbound/unbound.conf.d/*.conf"

--- a/services/unbound/general/unbound.d/etc-unbound/unbound/unbound.conf.d/pi-hole.conf
+++ b/services/unbound/general/unbound.d/etc-unbound/unbound/unbound.conf.d/pi-hole.conf
@@ -1,0 +1,66 @@
+server:
+    # If no logfile is specified, syslog is used
+    # logfile: "/var/log/unbound/unbound.log"
+    verbosity: 0
+
+    interface: 127.0.0.1      # Your pi-hole interface IP address
+    port: 5335                # Your pi-hole listening port number
+    do-ip4: yes
+    do-udp: yes
+    do-tcp: yes
+
+    # May be set to yes if you have IPv6 connectivity
+    do-ip6: no
+
+    # You want to leave this to no unless you have *native* IPv6. With 6to4 and
+    # Terredo tunnels your web browser should favor IPv4 for the same reasons
+    prefer-ip6: no
+
+    # Use this only when you downloaded the list of primary root servers!
+    # If you use the default dns-root-data package, unbound will find it automatically
+    #root-hints: "/var/lib/unbound/root.hints"
+
+    # Trust glue only if it is within the server's authority
+    harden-glue: yes
+
+    # Require DNSSEC data for trust-anchored zones, if such data is absent, the zone becomes BOGUS
+    harden-dnssec-stripped: yes
+
+    # Don't use Capitalization randomization as it known to cause DNSSEC issues sometimes
+    # see https://discourse.pi-hole.net/t/unbound-stubby-or-dnscrypt-proxy/9378 for further details
+    use-caps-for-id: no
+
+    # Reduce EDNS reassembly buffer size.
+    # IP fragmentation is unreliable on the Internet today, and can cause
+    # transmission failures when large DNS messages are sent via UDP. Even
+    # when fragmentation does work, it may not be secure; it is theoretically
+    # possible to spoof parts of a fragmented DNS message, without easy
+    # detection at the receiving end. Recently, there was an excellent study
+    # >>> Defragmenting DNS - Determining the optimal maximum UDP response size for DNS <<<
+    # by Axel Koolhaas, and Tjeerd Slokker (https://indico.dns-oarc.net/event/36/contributions/776/)
+    # in collaboration with NLnet Labs explored DNS using real world data from the
+    # the RIPE Atlas probes and the researchers suggested different values for
+    # IPv4 and IPv6 and in different scenarios. They advise that servers should
+    # be configured to limit DNS messages sent over UDP to a size that will not
+    # trigger fragmentation on typical network links. DNS servers can switch
+    # from UDP to TCP when a DNS response is too big to fit in this limited
+    # buffer size. This value has also been suggested in DNS Flag Day 2020.
+    edns-buffer-size: 1232
+
+    # Perform prefetching of close to expired message cache entries
+    # This only applies to domains that have been frequently queried
+    prefetch: yes
+
+    # One thread should be sufficient, can be increased on beefy machines. In reality for most users running on small networks or on a single machine, it should be unnecessary to seek performance enhancement by increasing num-threads above 1.
+    num-threads: 1
+
+    # Ensure kernel buffer is large enough to not lose messages in traffic spikes
+    so-rcvbuf: 1m
+
+    # Ensure privacy of local IP ranges
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    private-address: 172.16.0.0/12
+    private-address: 10.0.0.0/8
+    private-address: fd00::/8
+    private-address: fe80::/10

--- a/services/unbound/general/unbound.d/etc-unbound/unbound/unbound.conf.d/root-auto-trust-anchor-file.conf
+++ b/services/unbound/general/unbound.d/etc-unbound/unbound/unbound.conf.d/root-auto-trust-anchor-file.conf
@@ -1,0 +1,4 @@
+server:
+    # The following line will configure unbound to perform cryptographic
+    # DNSSEC validation using the root trust anchor.
+    auto-trust-anchor-file: "/var/lib/unbound/root.key"

--- a/services/unbound/raspberry-pi/docker-compose.yaml
+++ b/services/unbound/raspberry-pi/docker-compose.yaml
@@ -8,9 +8,7 @@ services:
       - "5335:5335/udp" # UDP port number for Unbound DNS resolver; Corresponds to the port number specified in the unbound configuration file
     restart: unless-stopped
     volumes:
-      - "./unbound.d/etc-unbound/unbound/:/opt/unbound/etc/unbound"
-    command:
-      - /bin/bash
-      - -c |
-        "dir /etc"
+      - "./unbound.d/etc-unbound/unbound/:/etc/unbound"
+
+
 

--- a/services/unbound/raspberry-pi/docker-compose.yaml
+++ b/services/unbound/raspberry-pi/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  unbound:
+    image: 'mvance/unbound-rpi:latest'
+    container_name: 'unbound'
+    ports:
+      - "5335:5335/tcp" # TCP port number for Unbound DNS resolver; Corresponds to the port number specified in the unbound configuration file
+      - "5335:5335/udp" # UDP port number for Unbound DNS resolver; Corresponds to the port number specified in the unbound configuration file
+    restart: unless-stopped
+    volumes:
+      - "./unbound.d/etc-unbound/unbound/:/opt/unbound/etc/unbound"
+    command:
+      - /bin/bash
+      - -c |
+        "dir /etc"
+

--- a/services/unbound/raspberry-pi/unbound.d/etc-unbound/unbound/unbound.conf
+++ b/services/unbound/raspberry-pi/unbound.d/etc-unbound/unbound/unbound.conf
@@ -1,0 +1,10 @@
+# Unbound configuration file for Debian.
+#
+# See the unbound.conf(5) man page.
+#
+# See /usr/share/doc/unbound/examples/unbound.conf for a commented
+# reference config file.
+#
+# The following line includes additional configuration files from the
+# /etc/unbound/unbound.conf.d directory.
+include-toplevel: "/etc/unbound/unbound.conf.d/*.conf"

--- a/services/unbound/raspberry-pi/unbound.d/etc-unbound/unbound/unbound.conf.d/pi-hole.conf
+++ b/services/unbound/raspberry-pi/unbound.d/etc-unbound/unbound/unbound.conf.d/pi-hole.conf
@@ -1,0 +1,67 @@
+server:
+    # If no logfile is specified, syslog is used
+    # logfile: "/var/log/unbound/unbound.log"
+    verbosity: 0
+
+    interface: 127.0.0.1      # Your pi-hole interface IP address
+    port: 5335                # Your pi-hole listening port number
+    access-control: 192.168.1.0/24 allow
+    do-ip4: yes
+    do-udp: yes
+    do-tcp: yes
+
+    # May be set to yes if you have IPv6 connectivity
+    do-ip6: no
+
+    # You want to leave this to no unless you have *native* IPv6. With 6to4 and
+    # Terredo tunnels your web browser should favor IPv4 for the same reasons
+    prefer-ip6: no
+
+    # Use this only when you downloaded the list of primary root servers!
+    # If you use the default dns-root-data package, unbound will find it automatically
+    #root-hints: "/var/lib/unbound/root.hints"
+
+    # Trust glue only if it is within the server's authority
+    harden-glue: yes
+
+    # Require DNSSEC data for trust-anchored zones, if such data is absent, the zone becomes BOGUS
+    harden-dnssec-stripped: yes
+
+    # Don't use Capitalization randomization as it known to cause DNSSEC issues sometimes
+    # see https://discourse.pi-hole.net/t/unbound-stubby-or-dnscrypt-proxy/9378 for further details
+    use-caps-for-id: no
+
+    # Reduce EDNS reassembly buffer size.
+    # IP fragmentation is unreliable on the Internet today, and can cause
+    # transmission failures when large DNS messages are sent via UDP. Even
+    # when fragmentation does work, it may not be secure; it is theoretically
+    # possible to spoof parts of a fragmented DNS message, without easy
+    # detection at the receiving end. Recently, there was an excellent study
+    # >>> Defragmenting DNS - Determining the optimal maximum UDP response size for DNS <<<
+    # by Axel Koolhaas, and Tjeerd Slokker (https://indico.dns-oarc.net/event/36/contributions/776/)
+    # in collaboration with NLnet Labs explored DNS using real world data from the
+    # the RIPE Atlas probes and the researchers suggested different values for
+    # IPv4 and IPv6 and in different scenarios. They advise that servers should
+    # be configured to limit DNS messages sent over UDP to a size that will not
+    # trigger fragmentation on typical network links. DNS servers can switch
+    # from UDP to TCP when a DNS response is too big to fit in this limited
+    # buffer size. This value has also been suggested in DNS Flag Day 2020.
+    edns-buffer-size: 1232
+
+    # Perform prefetching of close to expired message cache entries
+    # This only applies to domains that have been frequently queried
+    prefetch: yes
+
+    # One thread should be sufficient, can be increased on beefy machines. In reality for most users running on small networks or on a single machine, it should be unnecessary to seek performance enhancement by increasing num-threads above 1.
+    num-threads: 1
+
+    # Ensure kernel buffer is large enough to not lose messages in traffic spikes
+    so-rcvbuf: 1m
+
+    # Ensure privacy of local IP ranges
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    private-address: 172.16.0.0/12
+    private-address: 10.0.0.0/8
+    private-address: fd00::/8
+    private-address: fe80::/10

--- a/services/uptime-kuma/docker-compose.yaml
+++ b/services/uptime-kuma/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: 3.5"
+version: "3.5"
 
 services:
     # Uptime Kuma


### PR DESCRIPTION
[Updates]
- Cleaned up and updated 'pi-hole' service docker-compose file to include automated WebUI admin page password changing via Environment Variables as well as additional requirements
- Fixed Uptime Kuma version tag
- Updated root README file with changes to architecture support for the following services by the maintainers
    + pihole : tested at 2023-03-14 0959H; seems to be working with ARMv6 (using the Raspberry Pi Zero W)
- Updated services README file with new services added
    + unbound : DNS Resolver

[New]
- Added service 'unbound' DNS resolver

[Tests]
- Tested implementation of unbound in docker for non-ARM processor devices using the docker image repository 'mvance/unbound'
- Tested implementation of unbound in docker for ARM processor (i.e. RPI)
    - Findings
        + docker image repository 'mvance/unbound-rpi' doesnt support ARMv6, only ARMv7 and above

[WIP]
- Testing pihole with unbound