### PR TITLE
Update 2023-03-22 1025H | merge-updates-to-main

### DIFF
--- a/categorised/programming/README.md
+++ b/categorised/programming/README.md
@@ -1,0 +1,10 @@
+# Category: Programming/DevOps 
+
+* Programming/DevOps-related tools and utility docker and docker-compose files
+
+## Tools and Utilities
+### Types
++ [Compilers](#compilers)
+
+### Compilers
++ [Rust](Rust)

--- a/categorised/programming/rust/CHANGELOGS.md
+++ b/categorised/programming/rust/CHANGELOGS.md
@@ -1,0 +1,9 @@
+# CHANGELOGS
+
+## Changes
+- 2023-03-21 1443H | fixes
+    - Fixed docker-compose of Rust official image to work without a custom Dockerfile image (thanks 'tty: true')
+    - Added new key-values
+        + `tty: true`   : Corresponds to docker run's `docker run -itd`; To let rust container remain up so that user can keep compiling whenever he wants via `docker exec -it rust /bin/bash -c "command"`
+        + `working_dir` : Corresponds to Dockerfile's `WORKDIR [working directory]`; To set the startup working directory of the container
+

--- a/categorised/programming/rust/Dockerfile
+++ b/categorised/programming/rust/Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile
+# for 
+# Compiler: Rust
+
+## Pull latest image
+FROM rust:latest
+
+## Set Working Directory
+WORKDIR /rust/app/src
+
+## Copy necessary files
+COPY rust/app/src .
+
+
+
+
+

--- a/categorised/programming/rust/README.md
+++ b/categorised/programming/rust/README.md
@@ -1,0 +1,120 @@
+# Rust compiler dockerized
+
+* Contains a Dockerfile that will prepare the rust image to be used with the docker-compose file.
+
+## Information
+### Development
+* the [docker-compose file](docker-compose.yaml) is currently still a Work in Progress, trying to work out some issues regarding mounting.
+For the time being, please use the docker run method (which honestly, might be more efficient than using docker-compose for Development environment utilities/tools)
+
+## Setup
+### Pre-Requisites
++ have your Rust code ready
+- Rust project work structure/filesystem
+    - Must include the following
+        + Cargo.toml
+
+### Dependencies
++ docker(-ce)
++ docker-compose
+
+## Documentation
+### Using docker-compose
+- Running
+    ```console
+    docker-compose up -d --build
+    ```
+
+- Teardown
+    ```console
+    docker-compose down
+    ```
+
+### Using manual docker run
+- Build Dockerfile image
+    ```console
+    docker build -t [docker-image-name] [dockerfile-path]
+    ```
+- Run docker image
+    - General background
+        ```console
+        docker run -itd --name [container-name] [image-name] {other-commmands}
+        ```
+
+    - Run docker image with volume mapping (Recommended)
+        ```console
+        docker run -itd -v "[host-system-volume]:[container-volume]"  --name [container-name] [image-name] {other-commmands}
+        ```
+
+- Stop docker container
+    ```console
+    docker container stop [container-name]
+    ```
+- Remove docker container
+    ```console
+    docker container rm [container-name]
+    ```
+- Remove docker image
+    ```console
+    docker image rm [container-name]
+    ```
+
+### Debugging
+- Check issues with docker container
+    - Check container process
+        ```console
+        docker (container) ps
+        ```
+    - Check docker container logs
+        ```console
+        docker logs [container-name]
+        ```
+
+### Executing
+- Invoke cargo commands in container
+    - Create new project
+        ```console
+        docker exec -it [container-name] /bin/bash -c "cargo new [project-name]"
+        ```
+
+### Output
++ Upon running, the rust compiler will output the compiled binary file in '/app/bin'
+
+### Usage/Snippet Examples
+1. Cargo new project workspace
+    - Build dockerfile into image
+        ```console
+        docker build -t [new-docker-image-name] [path-to-dockerfile (i.e. '.')]
+        ```
+    - docker run and startup a container using built Dockerfile image 
+        + with Volume mounting : This is like using the key 'volume:' in a docker-compose environment to mount a folder in your host system to the container
+            + This lets you effectively get the files that will be output by rust, as well as let the docker environment see your source files
+        ```console
+        docker run -itd -v $(pwd)/rust/app/src:/rust/app/src --name [container-name] [docker-image-name]
+        ```
+    - Execute commands in container
+        - Create new project workspace
+            + Because you mounted the source file volume directory, the outputted project workspace is also found there
+            ```console
+            docker exec -it [container-name] /bin/bash -c "cargo new [project-name]"
+            ```
+    - Stop docker container
+        ```console
+        docker container stop [container-name]
+        ```
+    - Remove docker container
+        ```console
+        docker container rm [container-name]
+        ```
+    - Remove docker image
+        ```console
+        docker (image) stop [container-name]
+        ```
+
+## Resources
+
+## References
++ [FreeCodeCamp - How to mount local directories using `docker run -v`](https://www.freecodecamp.org/news/docker-mount-volume-guide-how-to-mount-a-local-directory/#:~:text=You%20bind%20local%20directories%20and,source%3E%3A%20.)
++ [DOcker blogs - Simplify your deployments using the rust official image](https://www.docker.com/blog/simplify-your-deployments-using-the-rust-official-image/)
+
+## Remarks

--- a/categorised/programming/rust/docker-compose.yaml
+++ b/categorised/programming/rust/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3.5"
+services:
+  rust:
+    image: rust
+    container_name: rust
+    build: .
+    restart: unless-stopped
+    volumes:
+      ## Mount source file
+      - "./rust/app/src:/rust/app/src"
+      ## Mount output binary folder
+      - "./rust/app/bin:/bin"
+

--- a/categorised/programming/rust/docker-compose.yaml
+++ b/categorised/programming/rust/docker-compose.yaml
@@ -3,11 +3,16 @@ services:
   rust:
     image: rust
     container_name: rust
-    build: .
-    restart: unless-stopped
+    # build: . # Uncomment this if you want to build your own Dockerfile
+    # restart: unless-stopped # Uncomment this if you want the docker-compose file to repeat; uncomment 'tty: true' as well to enter the stdin tty mode
+    tty: true # Corresponds to '-it' in docker run
+    working_dir: "/rust/app/src/my-project" # Corresponds to Dockerfile's WORKDIR option; This sets the startup working directory of the current container
     volumes:
+      ## Maps and Mount host system volumes to container volume
+      ## Syntax: [host system volume]:[container volume]{:permissions}
+      ## Mount applications directory
+      - "./rust/app:/rust/app"
       ## Mount source file
       - "./rust/app/src:/rust/app/src"
-      ## Mount output binary folder
-      - "./rust/app/bin:/bin"
+    command: "cargo build --release" # automatically execute the cargo build command; Comment this if you want to go into tty mode
 

--- a/categorised/programming/rust/rust/app/bin/your-output-here.md
+++ b/categorised/programming/rust/rust/app/bin/your-output-here.md
@@ -1,0 +1,2 @@
+# Your binary output will be placed here
+

--- a/categorised/programming/rust/rust/app/src/main.rs
+++ b/categorised/programming/rust/rust/app/src/main.rs
@@ -1,0 +1,4 @@
+fn main()
+{
+    println!("Congratulations! Your application is successfully containerized with Docker!!");
+}

--- a/services/apache/apache/var/www/html/index.html
+++ b/services/apache/apache/var/www/html/index.html
@@ -1,0 +1,11 @@
+<html>
+    <head>
+        <title>Hello World</title>
+    </head>
+
+    <body>
+        <p>
+            Hello World
+        </p>
+    </body>
+</html>

--- a/services/apache/docker-compose.yaml
+++ b/services/apache/docker-compose.yaml
@@ -1,0 +1,22 @@
+# Docker-compose for
+# Web Server utility
+# Service Author: apache
+# Service Name: apache (aka httpd)
+# URL: https://github.com/apache/httpd
+# Configurations: 
+
+version: "3.5"
+services:
+  apache:
+    image: httpd:latest
+    container_name: apache
+    restart: unless-stopped
+    ports:
+      # Port forwarding/translation from host system port to container port
+      # [host system port]:[container port]
+      - "8080:80"
+    volumes:
+      # - "./apache/var/www/html:/var/www/html" # Data folder
+      - "./apache/var/www/html:/usr/local/apache2/htdocs" # Data folder
+      
+

--- a/services/phpmyadmin/docker-compose.yaml
+++ b/services/phpmyadmin/docker-compose.yaml
@@ -1,0 +1,35 @@
+# Docker-compose for
+# Database Management System (DBMS)
+# Service Author: phpmyadmin
+# Service Name: phpmyadmin
+# URL: https://github.com/phpmyadmin/phpmyadmin
+# Configurations: 
+
+version: "3.5"
+services:
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: phpmyadmin
+    restart: unless-stopped
+      # Define your environment variables here
+      # OR
+      # Define in an .env file
+      # --------------------------------------------------
+      # Uncomment the following to define here
+      #environment:
+      #- PMA_HOST=[your-phmyadmin-host-username]
+      #- PMA_PORT=[your-phpmyadmin-host-port]
+      #- PMA_ARBITRARY=[1|0]
+      #
+      # Environment Variables file
+      # Please define all your environment variables in here if you dont want to 
+      # specify them within the docker-compose file via the 'environment' key
+      # --------------------------------------------------
+      # Uncomment the following to use the env file
+    env_file: 
+      - "./phpmyadmin/.env"
+    ports:
+      # Port forwarding/translation from host system port to container port
+      # [host system port]:[container port]
+      - "8080:80"
+

--- a/services/phpmyadmin/phpmyadmin/.env
+++ b/services/phpmyadmin/phpmyadmin/.env
@@ -1,0 +1,7 @@
+# PMA_HOST=[replace-with-your-phpmyadmin-hostname]
+# PMA_PORT=[replace-with-your-phpmyadmin-port-number]
+# PMA_ARBITRARY=[replace-with-1-or-0]
+PMA_HOST=db
+PMA_PORT=3306
+PMA_ARBITRARY=1
+


### PR DESCRIPTION
[New]
- Created new folder 'categorised' in ~/ for all specific categorised/topical docker utilities and tools such as Programming utilities having compilers, Networking etc
- Created new folder 'programming' in 'categorised' for all Programming-related services/utilities/tools such as compilers, devops environments etc., formally now known as 'services'
- Added new folder for Rust compiler docker service => 'categorised/programming/Rust'
- Added new key-values to docker-compose of Rust official image service
    + tty: true   : Corresponds to docker run's 'docker run -itd'; To let rust container remain up so that user can keep compiling whenever he wants via `docker exec -it rust /bin/bash -c ''command'''
    + working_dir : Corresponds to Dockerfile's 'WORKDIR [working directory]'; To set the startup working directory of the container
- Created a CHANGELOG.md to store all CHANGELOGS per service
- Added new Database Management Service/System (DBMS) service 'phpmyadmin'
- Added new Web Server service 'apache'

[Updates]
- Fixed docker-compose of Rust official image to work without a custom Dockerfile image (thanks 'tty: true')

